### PR TITLE
get single comment works

### DIFF
--- a/comments/__init__.py
+++ b/comments/__init__.py
@@ -2,3 +2,4 @@ from .request import get_comments_by_post
 from .request import create_comment
 from .request import delete_comment
 from .request import update_comment
+from .request import get_single_comment

--- a/comments/request.py
+++ b/comments/request.py
@@ -84,3 +84,29 @@ def update_comment(id, subject, content):
             return False
         else:
             return True
+
+def get_single_comment(id):
+    with sqlite3.connect("./rare.db") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(""" 
+        SELECT
+        c.id,
+        c.subject,
+        c.content,
+        c.user_id,
+        u.user_name,
+        c.post_id,
+        p.title
+        FROM Comment C
+        JOIN User u ON u.id = c.user_id
+        JOIN Post p ON p.id = c.post_id
+        WHERE c.id = ?
+        """, (id,))
+
+        data = db_cursor.fetchone()
+
+        comment = Comment(data['id'], data['subject'], data['content'], data['user_id'], data['user_name'], data['post_id'], data['title'])
+
+    return json.dumps(comment.__dict__)

--- a/models/comment.py
+++ b/models/comment.py
@@ -1,8 +1,10 @@
 class Comment():
-    def __init__(self, id, subject, content, user_id, post_id):
+    def __init__(self, id, subject, content, user_id, user_name, post_id, title):
         self.id = id
         self.subject = subject
         self.content = content
         self.user_id = user_id
+        self.user_name = user_name
         self.post_id = post_id
+        self.post_title = title
         

--- a/rare.sql
+++ b/rare.sql
@@ -172,7 +172,7 @@ SELECT * FROM Comment;
 -- >
 
 -- <4. Run the following and ensure all 3 items were deleted:
-SELECT * From Post
+SELECT * From Post;
 WHERE id = 7;
 SELECT * FROM TagPost;
 SELECT * FROM Comment;
@@ -210,7 +210,7 @@ FROM Post p
 JOIN User u ON u.id = p.user_id
 JOIN Category c ON c.id = p.category_id
 JOIN Comment com on com.post_id = p.id
-WHERE p.id = 1;
+WHERE p.id = 26;
 
 
 SELECT

--- a/request_handler.py
+++ b/request_handler.py
@@ -4,7 +4,7 @@ import json
 from categories import get_all_categories, get_single_category, delete_category, create_category, update_category
 from posts import get_all_posts, get_single_post, get_posts_by_category, create_new_post, delete_post, get_posts_by_user, update_post
 from users import create_user, get_user_by_email
-from comments import get_comments_by_post, create_comment, delete_comment
+from comments import get_comments_by_post, create_comment, delete_comment, get_single_comment
 from tags import get_all_tags, create_tag
 
 class HandleRequests(BaseHTTPRequestHandler):
@@ -76,6 +76,10 @@ class HandleRequests(BaseHTTPRequestHandler):
 					response = f"{get_single_post(id)}"
 				else:
 					response = f"{get_all_posts()}"
+
+			if resource == "comments":
+				if id is not None:
+					response = f"{get_single_comment(id)}"
 
 			if resource == "tags":
 				response = f"{get_all_tags()}"


### PR DESCRIPTION
# Description

Enables a user to get a single comment by the comment id

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `git fetch --all`
- `git checkout cj-get-single-comment`
- in postman use the `POST` method with URL ` http://localhost:8088/comments`
- select in params under URL `Body`, `raw`, `JSON`
- past `{"subject" : "wow a new subject", "content" : "yo, its content", "user_id" : (use one from your db), "post_id": (use one from your db)}`
- after the new comment is created, in Postman use the `GET` method with URL `http://localhost:8088/comments/(the id of the comment you just created)`
- it will return the comment that matches that id


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
